### PR TITLE
add "scope" to default manifest

### DIFF
--- a/blueprints/ember-web-app/files/config/manifest.js
+++ b/blueprints/ember-web-app/files/config/manifest.js
@@ -9,6 +9,7 @@ module.exports = function(/* environment, appConfig */) {
     short_name: "<%= name %>",
     description: "",
     start_url: "/",
+    scope: "/",
     display: "standalone",
     background_color: "#fff",
     theme_color: "#fff",

--- a/node-tests/acceptance/manifest-test.js
+++ b/node-tests/acceptance/manifest-test.js
@@ -33,6 +33,7 @@ describe('Acceptance', function () {
             short_name: 'empty',
             description: '',
             start_url: '/',
+            scope: '/',
             display: 'standalone',
             background_color: '#fff',
             theme_color: '#fff',


### PR DESCRIPTION
This is necessary for iOS devices to not trigger the "in-app browser" functionality for pages that are not `/`.